### PR TITLE
Fixed Issue #3 & #4 & some more improvements

### DIFF
--- a/video-metrics.py
+++ b/video-metrics.py
@@ -288,7 +288,7 @@ else:
 	chosen_presets = args.preset
 	presets_string = ','.join(chosen_presets)	
 	print(f'Presets {presets_string} will be compared at a CRF of {crf_value[0]}.')
-	output_folder = f'({filename})/Presets comparison at CRF {crf_value}'
+	output_folder = f'({filename})/Presets comparison at CRF {crf_value[0]}'
 	os.makedirs(output_folder, exist_ok=True)
 	comparison_table = os.path.join(output_folder, 'Table.txt')
 	table_column_names.insert(0, 'Preset')

--- a/video-metrics.py
+++ b/video-metrics.py
@@ -178,7 +178,7 @@ original_video_size = os.path.getsize(original_video) / 1_000_000
 filename = original_video.split('/')[-1]
 output_ext = os.path.splitext(original_video)[-1][1:]
 
-print(f'File: {filename}')
+print(f'\nFile: {filename}')
 cap = cv2.VideoCapture(original_video)
 fps = str(cap.get(cv2.CAP_PROP_FPS))
 print(f'Framerate: {fps} FPS')
@@ -213,10 +213,11 @@ if args.no_transcoding_mode:
 # If len(args.crf_value) > 1 then more than one CRF value was specified so the user wants to compare CRF values.
 elif len(args.crf_value) > 1:
 
-	print('More than one CRF value specified. CRF comparison mode activated.')
+	print('\nMore than one CRF value specified. CRF comparison mode activated.')
 	crf_values = args.crf_value
 	chosen_preset = args.preset
-	print(f'CRF values {crf_values} will be compared and the {chosen_preset[0]} preset will be used.')
+	CRF_values_string = ','.join(map(str, crf_values))
+	print(f'CRF values {CRF_values_string} will be compared and the {chosen_preset[0]} preset will be used.')
 	video_encoder = args.video_encoder
 	
 	# Where the data will be saved.
@@ -281,11 +282,12 @@ elif len(args.crf_value) > 1:
 
 # The user wants to compare presets.
 else:
-	print('Presets comparison mode activated.')
+	print('\nPresets comparison mode activated.')
 	video_encoder = args.video_encoder
 	crf_value = args.crf_value
 	chosen_presets = args.preset
-	print(f'Presets {chosen_presets} will be compared at a CRF of {crf_value}.')
+	presets_string = ','.join(chosen_presets)	
+	print(f'Presets {presets_string} will be compared at a CRF of {crf_value[0]}.')
 	output_folder = f'({filename})/Presets comparison at CRF {crf_value}'
 	os.makedirs(output_folder, exist_ok=True)
 	comparison_table = os.path.join(output_folder, 'Table.txt')
@@ -308,18 +310,17 @@ else:
 		time_message = f' for {args.encoding_time} seconds' if int(args.encoding_time) > 1 else 'for 1 second'
 
 		with open(comparison_table, 'w') as f:
-			f.write(f'You chose to encode {filename}{time_message} using {args.video_encoder} with a CRF of {args.crf_value}.\n'
+			f.write(f'You chose to encode {filename}{time_message} using {args.video_encoder} with a CRF of {crf_value}.\n'
 					f'PSNR/SSIM/VMAF values are in the format: Min | Standard Deviation | Mean\n')
 
 	# Transcode the video with each preset.
 	for preset in chosen_presets:
-		print(args.crf_value)
 		transcode_output_path = os.path.join(output_folder, f'{preset}.{output_ext}')
 		graph_title = f"Preset '{preset}'"
 		subprocess_args = [
 			"ffmpeg", "-loglevel", "warning", "-stats", "-y",
 			"-i", original_video, "-map", "0",
-			"-c:v", f'lib{video_encoder}', "-crf", str(args.crf_value), "-preset", preset,
+			"-c:v", f'lib{video_encoder}', "-crf", str(crf_value[0]), "-preset", preset,
 			"-c:a", "copy", "-c:s", "copy", "-movflags", "+faststart", transcode_output_path
 		]
 		separator()

--- a/video-metrics.py
+++ b/video-metrics.py
@@ -56,9 +56,11 @@ print("For more information, enter 'python video-metrics.py -h'")
 separator()
 
 def compute_metrics(transcoded_video, output_folder, json_file_path, graph_title, crf_or_preset=None):
+	preset_string = ','.join(args.preset)
 	# The first line of Table.txt:
 	with open(comparison_table, 'w') as f:
 		f.write(f'PSNR/SSIM/VMAF values are in the format: Min | Standard Deviation | Mean\n')
+		f.write(f'Chosen preset(s): {preset_string}\n')
 
 	size_of_file = os.path.getsize(transcoded_video) / 1_000_000
 	size_compared_to_original = round(((size_of_file / original_video_size) * 100), 3) 
@@ -207,11 +209,11 @@ elif isinstance(args.crf_value, list):
 	print('More than one CRF value specified. CRF comparison mode activated.')
 	crf_values = args.crf_value
 	chosen_preset = args.preset
-	print(f'CRF values {crf_values} will be compared and the {chosen_preset} will be used.')
+	print(f'CRF values {crf_values} will be compared and the {chosen_preset[0]} preset will be used.')
 	video_encoder = args.video_encoder
 	
 	# Where the data will be saved.
-	output_folder = f'({filename})/CRF Comparison'
+	output_folder = f'({filename})/CRF Comparison ({chosen_preset[0]})'
 	os.makedirs(output_folder, exist_ok=True)
 	# The comparison table will be in the following path:
 	comparison_table = os.path.join(output_folder, 'Table.txt')
@@ -240,8 +242,8 @@ elif isinstance(args.crf_value, list):
 
 	# Transcode the video with each preset.
 	for crf in crf_values:
-		transcode_output_path = os.path.join(output_folder, f'CRF {crf}.{output_ext}')
-		graph_title = f'CRF {crf}, preset {chosen_preset}'
+		transcode_output_path = os.path.join(output_folder, f'CRF {crf} preset {chosen_preset[0]}.{output_ext}')
+		graph_title = f'CRF {crf} preset {chosen_preset[0]}'
 
 		subprocess_args = [
 			"ffmpeg", "-loglevel", "warning", "-stats", "-y",
@@ -264,7 +266,6 @@ elif isinstance(args.crf_value, list):
 			os.makedirs(os.path.join(output_folder, 'Raw JSON Data'), exist_ok=True)
 			json_file_path = f'{output_folder}/Raw JSON Data/CRF {crf}.json'
 			# (os.path.join doesn't work with libvmaf's log_path option)
-			graph_title = f'CRF {crf}'
 			compute_metrics(transcode_output_path, output_folder, json_file_path, graph_title, crf)
 
 		# -dqs argument specified

--- a/video-metrics.py
+++ b/video-metrics.py
@@ -210,8 +210,8 @@ if args.no_transcoding_mode:
 	transcoded_video = args.transcoded_video_path
 	compute_metrics(transcoded_video, output_folder, json_file_path, graph_title)
 
-# If args.crf_value is a list, more than one CRF value was specified so the user wants to compare CRF values.
-elif isinstance(args.crf_value, list):
+# If len(args.crf_value) > 1 then more than one CRF value was specified so the user wants to compare CRF values.
+elif len(args.crf_value) > 1:
 
 	print('More than one CRF value specified. CRF comparison mode activated.')
 	crf_values = args.crf_value

--- a/video-metrics.py
+++ b/video-metrics.py
@@ -142,7 +142,7 @@ def compute_metrics(transcoded_video, output_folder, json_file_path, graph_title
 
 		if not args.no_transcoding_mode:
 			# CRF comparison mode if a list of CRF values were provided.
-			if isinstance(args.crf_value, list):
+			if len(args.crf_value) > 1:
 				data_for_current_row.insert(0, crf)
 				data_for_current_row.insert(1, time_rounded)
 			# Presets comparison mode.

--- a/video-metrics.py
+++ b/video-metrics.py
@@ -1,4 +1,4 @@
-import argparse, cv2, time, os, subprocess, json
+import argparse, cv2, time, os, subprocess, json, sys
 from argparse import RawTextHelpFormatter
 from prettytable import PrettyTable
 import numpy as np
@@ -48,6 +48,13 @@ args = parser.parse_args()
 
 def separator():
 	print('-----------------------------------------------------------------------------------------------------------') 
+
+# If more than one CRF value and more than one preset was specified then we don't have a suitable comparison mode. Exit.
+if len(args.crf_value) > 1 and len(args.preset) > 1:
+	separator()
+	print(f'More than one CRF value AND more than one preset specified. No suitable mode found. Exiting.')
+	separator()
+	sys.exit()
 
 separator()
 print('If the path contains a space, the path argument must be surrounded in double quotes. Example:')


### PR DESCRIPTION
This

- adds used presets to the title of table.txt
- adds used preset to folder name \CRF Comparison (preset)\
- adds used preset to output files for ffmpeg and graphs
- exits the script when more than one CRF value and more than one preset are specified
- checks if more than one CRF value was specified and only then enters CRF comparison mode 
- improves displaying specified CRF values and presets and adds a line break here and there