### PR TITLE
fixes issue #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Available arguments:
                         The path of the transcoded video (only applicable when using the -ntm mode).
 ```
 # Requirements:
-- Python **3.6+**
+- Python **3.6+ - 3.8.6** (no opencv wheel for python 3.9 available yet)**
 - FFmpeg installed and in your PATH. Your build of FFmpeg must have `--enable-libvmaf` in the configuration (unless you don't care about the quality metrics and you specify `-dqs` when running this command line program). If you're on Windows, you can download an FFmpeg binary which has `--enable-libvmaf` in the configuration by clicking on [this](http://learnffmpeg.s3.amazonaws.com/ffmpeg-vmaf-static-bin.zip) link.
 - The files **vmaf_v0.6.1.pkl** and **vmaf_v0.6.1.pkl.model** need to be in the same directory as video-metrics.py. These files are not needed if you only want the encoding time and filesize to be shown (you must specify `-dqs` in this case).
 - `pip install -r requirements.txt`

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-opencv_python==4.3.0.36
-numpy==1.18.2
-matplotlib==3.3.0
-prettytable==0.7.2
+opencv_python>=4.3.0.36
+numpy>=1.18.2
+matplotlib>=3.3.0
+prettytable>=0.7.2


### PR DESCRIPTION
don't use exact versions but minimum versions instead
no opencv wheel for Python 3.9 and building it is no recommended so better not support it officially