### PR TITLE
Changed numpy requirement to work with Python 3.8.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 prettytable==0.7.2
 moviepy==1.0.3
-numpy==1.19.4
+numpy>=1.18.2
 matplotlib==3.3.0


### PR DESCRIPTION
See https://github.com/BassThatHertz/video-quality-metrics/commit/95bdbfcb10a61c56ee6647b73c0bbe01154d53e5#commitcomment-43858302