### PR TITLE
VQM now also works with UNC paths

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 import os
 import sys
 from argparse import ArgumentParser, RawTextHelpFormatter
-
+from pathlib import Path
 from prettytable import PrettyTable
 
 from save_metrics import create_table_plot_metrics, force_decimal_places
@@ -86,8 +86,9 @@ def main():
         exit_program('Argument validation failed.')
 
     original_video_path = args.original_video_path
-    filename = original_video_path.split('/')[-1]
-    output_ext = os.path.splitext(original_video_path)[-1][1:]
+    filename = Path(original_video_path).name
+    # this includes the dot eg '.mp4'
+    output_ext = Path(original_video_path).suffix
     clips_interval = args.interval
     decimal_places = args.decimal_places
 
@@ -105,8 +106,8 @@ def main():
     line()
 
     # The M4V container does not support the H.265 codec.
-    if output_ext == 'm4v' and args.video_encoder == 'x265':
-        output_ext = 'mp4' 
+    if output_ext == '.m4v' and args.video_encoder == 'x265':
+        output_ext = '.mp4'
 
     # Create a PrettyTable object.
     table = PrettyTable()
@@ -162,7 +163,7 @@ def main():
 
             # Transcode the video with each CRF value.
             for crf in crf_values:
-                transcode_output_path = os.path.join(output_folder, f'CRF {crf}.{output_ext}')
+                transcode_output_path = os.path.join(output_folder, f'CRF {crf}{output_ext}')
                 graph_filename = f'CRF {crf} at preset {preset}'
 
                 arguments = EncodingArguments()
@@ -230,7 +231,7 @@ def main():
 
             # Transcode the video with each preset.
             for preset in chosen_presets:
-                transcode_output_path = os.path.join(output_folder, f'{preset}.{output_ext}')
+                transcode_output_path = os.path.join(output_folder, f'{preset}{output_ext}')
                 graph_filename = f"Preset '{preset}'"
                 
                 arguments = EncodingArguments()
@@ -307,7 +308,7 @@ def main():
 
 
 def cut_video(filename, args, output_ext, output_folder, comparison_table):
-    cut_version_filename = f'{os.path.splitext(filename)[0]} [{args.encoding_time}s].{output_ext}'
+    cut_version_filename = f'{Path(filename).stem} [{args.encoding_time}s]{output_ext}'
     # Output path for the cut video.
     output_file_path = os.path.join(output_folder, cut_version_filename)
     # The reference file will be the cut version of the video.

--- a/overview.py
+++ b/overview.py
@@ -1,4 +1,11 @@
-import time, os, math, subprocess, shutil
+import os
+import math
+import subprocess
+import shutil
+import time
+
+from pathlib import Path
+
 from utils import VideoInfoProvider, line, exit_program
 
 
@@ -21,7 +28,7 @@ def create_clips(video_path, output_folder, interval_seconds, clip_length):
     output_folder = os.path.join(output_folder, 'clips')
 
     if not os.path.exists(video_path):
-        raise ClipError(f'The specified video file does not exist.')
+        raise ClipError('The specified video file does not exist.')
 
     if not os.path.exists(output_folder):
         os.mkdir(output_folder)
@@ -68,7 +75,7 @@ def concatenate_clips(txt_file_path, output_folder, extension, interval_seconds,
     if not os.path.exists(txt_file_path):
         raise ConcatenateError(f'{txt_file_path} does not exist.')
 
-    overview_filename = f'{clip_length}-{interval_seconds} (ClipLength-IntervalSeconds).{extension}'
+    overview_filename = f'{clip_length}-{interval_seconds} (ClipLength-IntervalSeconds){extension}'
     concatenated_filepath = os.path.join(output_folder, overview_filename)
 
     subprocess_concatenate_args = [
@@ -88,7 +95,7 @@ def concatenate_clips(txt_file_path, output_folder, extension, interval_seconds,
 
 
 def create_movie_overview(video_path, output_folder, interval_seconds, clip_length):
-    extension = os.path.splitext(video_path)[-1][1:]
+    extension = Path(video_path).suffix
     try:
         txt_file_path = create_clips(video_path, output_folder, interval_seconds, clip_length)
         output_file = concatenate_clips(txt_file_path, output_folder, extension, interval_seconds, clip_length)
@@ -101,6 +108,6 @@ def create_movie_overview(video_path, output_folder, interval_seconds, clip_leng
         exit_program(err.args[0])
 
     if result:
-        print(f'Overview Video: {clip_length}-{interval_seconds} (ClipLength-IntervalSeconds).{extension}')
+        print(f'Overview Video: {clip_length}-{interval_seconds} (ClipLength-IntervalSeconds){extension}')
         line()
         return result, output_file


### PR DESCRIPTION
eg `\\server\share\file.mp4`

prior way of getting filename and extension was unreliable and would often cause weird naming issues for the output folder.
Fixed now.

```
>>> filename = '\\server\share\movies\my_super_duper_movie.mp4'
>>> filename.split('/')[-1] #this is the old way
'\\server\\share\\movies\\my_super_duper_movie.mp4'
>>> from pathlib import Path
>>> Path(filename).name
'my_super_duper_movie.mp4'
>>> Path(filename).suffix
'.mp4'
```

also unified the way we get the file extension