### PR TITLE
Fixes and improvements for optional metrics support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ _Example SSIM and PSNR graphs can be found in the [Example Graphs folder](https:
 - Bitrate (Mbps)
 - Filesize compared to the original video (as a percentage)
 - [Video Multimethod Assessment Fusion (VMAF)](https://github.com/Netflix/vmaf) values. VMAF is a perceptual video quality assessment algorithm developed by Netflix.
-- [Optional] Structural Similarity Index (SSIM). _You must use the `-ssim` argument._
 - [Optional] Peak Signal-to-Noise-Ratio (PSNR). _You must use the `-psnr` argument._
+- [Optional] Structural Similarity Index (SSIM). _You must use the `-ssim` argument._
+- [Optional] Multi-Scale Structural Similarity Index (MS-SSIM). _You must use the `-msssim` argument._
 
 If feature **[2]** is used, in addition to the above, the following colums are present:
 
@@ -116,7 +117,7 @@ You can find the output of `python main.py -h` below:
 
 ```
 usage: main.py [-h] [--av1-cpu-used <1-8>] [-cl <1-60>] [-crf <0-51> [<0-51> ...]] [-dp DECIMAL_PLACES] [-e {x264,x265,libaom-av1}] [-i <1-600>] [-subsample SUBSAMPLE]
-               [--n-threads N_THREADS] [-ntm] [-o OUTPUT_FOLDER] -ovp ORIGINAL_VIDEO_PATH [-p <preset/s> [<preset/s> ...]] [--phone-model] [-psnr] [-sc] [-ssim]
+               [--n-threads N_THREADS] [-ntm] [-o OUTPUT_FOLDER] -ovp ORIGINAL_VIDEO_PATH [-p <preset/s> [<preset/s> ...]] [--phone-model] [-sc] [-psnr] [-ssim] [-msssim]
                [-t SECONDS] [-tvp TRANSCODED_VIDEO_PATH] [-vf VIDEO_FILTERS]
 
 optional arguments:
@@ -174,6 +175,8 @@ Optional Metrics:
                         Enable PSNR calculation in addition to VMAF (default: False)
   -ssim, --calculate-ssim
                         Enable SSIM calculation in addition to VMAF (default: False)
+  -msssim, --calculate-msssim
+                        Enable MS-SSIM calculation in addition to VMAF (default: False)
 ```
 
 # About the model files

--- a/args.py
+++ b/args.py
@@ -171,6 +171,12 @@ optional_metrics_args.add_argument(
     action="store_true",
     help="Enable SSIM calculation in addition to VMAF",
 )
+optional_metrics_args.add_argument(
+    "-msssim",
+    "--calculate-msssim",
+    action="store_true",
+    help="Enable MS-SSIM calculation in addition to VMAF",
+)
 
 # Use only the first x seconds of the original video.
 general_args.add_argument(

--- a/libvmaf.py
+++ b/libvmaf.py
@@ -24,18 +24,18 @@ def run_libvmaf(
 
     n_subsample = "1" if not args.subsample else args.subsample
 
-    model_params = [
+    model_params = filter(None, [
         f"path={model_file_path}",
         "enable_transform=true" if args.phone_model else ""
-    ]
-    model_string = f"model='{'|'.join(filter(None, model_params))}'"
+    ])
+    model_string = f"model='{'|'.join(model_params)}'"
 
-    features = [
+    features = filter(None, [
         "name=psnr" if args.calculate_psnr else "",
         "name=float_ssim" if args.calculate_ssim else "",
         "name=float_ms_ssim" if args.calculate_msssim else ""
-    ]
-    feature_string = f":feature='{'|'.join(filter(None, features))}'"
+    ])
+    feature_string = f":feature='{'|'.join(features)}'"
 
     vmaf_options = f"""
     {model_string}:log_fmt=json:log_path='{json_file_path}':n_subsample={n_subsample}:n_threads={args.n_threads}{feature_string}

--- a/libvmaf.py
+++ b/libvmaf.py
@@ -23,13 +23,22 @@ def run_libvmaf(
             json_file_path = json_file_path.replace(character, f"\{character}")
 
     n_subsample = "1" if not args.subsample else args.subsample
-    psnr_string = ":feature='name=psnr'" if args.calculate_psnr else ""
-    ssim_string = ":feature='name=float_ssim'" if args.calculate_ssim else ""
-    phone_model_string = ":model='enable_transform=true'" if args.phone_model else ""
+
+    model_params = [
+        f"path={model_file_path}",
+        "enable_transform=true" if args.phone_model else ""
+    ]
+    model_string = f"model='{'|'.join(filter(None, model_params))}'"
+
+    features = [
+        "name=psnr" if args.calculate_psnr else "",
+        "name=float_ssim" if args.calculate_ssim else "",
+        "name=float_ms_ssim" if args.calculate_msssim else ""
+    ]
+    feature_string = f":feature='{'|'.join(filter(None, features))}'"
 
     vmaf_options = f"""
-    model=path={model_file_path}:log_fmt=json:log_path={json_file_path}:n_subsample={n_subsample}
-    :n_threads={args.n_threads}{psnr_string}{ssim_string}{phone_model_string}
+    {model_string}:log_fmt=json:log_path='{json_file_path}':n_subsample={n_subsample}:n_threads={args.n_threads}{feature_string}
     """
 
     libvmaf_arguments = LibVmafArguments(

--- a/libvmaf.py
+++ b/libvmaf.py
@@ -1,5 +1,5 @@
 from ffmpeg_process_factory import LibVmafArguments
-from utils import line, Logger
+from utils import line, Logger, get_metrics_list
 
 log = Logger("libvmaf")
 
@@ -40,23 +40,21 @@ def run_libvmaf(
 
     process = factory.create_process(libvmaf_arguments, args)
 
-    if args.calculate_psnr and args.calculate_ssim:
-        end_of_computing_message = ", PSNR and SSIM"
-    elif args.calculate_psnr:
-        end_of_computing_message = " and PSNR"
-    elif args.calculate_ssim:
-        end_of_computing_message = " and SSIM"
-    else:
-        end_of_computing_message = ""
+    metrics_list = get_metrics_list(args)
 
+    metric_types = metrics_list[0]
+    if len(metrics_list) > 1:
+        metric_types = f"{', '.join(metrics_list[:-1])} and {metrics_list[-1]}"
+
+    message_transcoding_mode = ""
     if not args.no_transcoding_mode:
         if isinstance(args.crf, list) and len(args.crf) > 1:
-            end_of_computing_message += f" achieved with CRF {crf_or_preset}"
+            message_transcoding_mode += f" achieved with CRF {crf_or_preset}"
         else:
-            end_of_computing_message += f" achieved with preset {crf_or_preset}"
+            message_transcoding_mode += f" achieved with preset {crf_or_preset}"
 
     line()
-    log.info(f"Calculating the VMAF{end_of_computing_message}...")
+    log.info(f"Calculating the {metric_types}{message_transcoding_mode}...")
 
     process.run(original_video_path, duration)
     log.info("Done!")

--- a/main.py
+++ b/main.py
@@ -22,6 +22,7 @@ from utils import (
     plot_graph,
     VideoInfoProvider,
     write_table_info,
+    get_metrics_list,
 )
 
 log = Logger("main.py")
@@ -88,14 +89,11 @@ if args.video_filters:
     line()
 
 table = PrettyTable()
-table_column_names = ["Encoding Time (s)", "Size", "Bitrate", "VMAF"]
+metrics_list = get_metrics_list(args)
+table_column_names = ["Encoding Time (s)", "Size", "Bitrate"] + metrics_list
 
 if args.no_transcoding_mode:
     del table_column_names[0]
-if args.calculate_ssim:
-    table_column_names.append("SSIM")
-if args.calculate_psnr:
-    table_column_names.append("PSNR")
 
 if args.interval is not None:
     output_folder = f"({filename})"

--- a/metrics.py
+++ b/metrics.py
@@ -31,6 +31,7 @@ def get_metrics_save_table(
         "VMAF": "vmaf",
         "PSNR": "psnr_y",
         "SSIM": "float_ssim",
+        "MS-SSIM": "float_ms_ssim"
     }
 
     # Only used for accessing the VMAF mean score to return at the end of this method.

--- a/metrics.py
+++ b/metrics.py
@@ -4,7 +4,7 @@ import os
 import matplotlib.pyplot as plt
 import numpy as np
 
-from utils import force_decimal_places, line, Logger, plot_graph
+from utils import force_decimal_places, line, Logger, plot_graph, get_metrics_list
 
 log = Logger("save_metrics")
 
@@ -23,95 +23,60 @@ def get_metrics_save_table(
     with open(json_file_path, "r") as f:
         file_contents = json.load(f)
 
-    # Get the VMAF score of each frame from the JSON file created by libvmaf.
-    vmaf_scores = [frame["metrics"]["vmaf"] for frame in file_contents["frames"]]
+    frames = file_contents["frames"]
+    frame_numbers = [frame["frameNum"] for frame in frames]
 
-    # Calculate the mean, minimum and standard deviation.
-    mean_vmaf = force_decimal_places(np.mean(vmaf_scores), decimal_places)
-    min_vmaf = force_decimal_places(min(vmaf_scores), decimal_places)
-    vmaf_std = force_decimal_places(np.std(vmaf_scores), decimal_places)
+    # Maps the metric type to the corresponding JSON metric key.
+    metric_lookup = {
+        "VMAF": "vmaf",
+        "PSNR": "psnr_y",
+        "SSIM": "float_ssim",
+    }
 
-    frame_numbers = [frame["frameNum"] for frame in file_contents["frames"]]
+    # Only used for accessing the VMAF mean score to return at the end of this method.
+    collected_scores = {}
+    # Process metrics captured for each requested metric type.
+    metrics_list = get_metrics_list(args)
+    for metric_type in metrics_list:
+        metric_key = metric_lookup[metric_type]
+        if frames[0]["metrics"][metric_key]:
+            # Get the <metric_type> score of each frame from the JSON file created by libvmaf.
+            metric_scores = [frame["metrics"][metric_key] for frame in frames]
 
-    plot_graph(
-        f"VMAF\nn_subsample: {args.subsample}",
-        "Frame Number",
-        "VMAF",
-        frame_numbers,
-        vmaf_scores,
-        mean_vmaf,
-        os.path.join(output_folder, "VMAF"),
-    )
+            # Calculate the mean, minimum and standard deviation scores across all frames.
+            mean_score = force_decimal_places(np.mean(metric_scores), decimal_places)
+            min_score = force_decimal_places(min(metric_scores), decimal_places)
+            std_score = force_decimal_places(np.std(metric_scores), decimal_places)
 
-    # Add the VMAF values to the table.
-    data_for_current_row.append(f"{min_vmaf} | {vmaf_std} | {mean_vmaf}")
+            collected_scores[metric_type] = {
+                "min": min_score,
+                "std": std_score,
+                "mean": mean_score
+            }
 
-    ssim_string = ""
-    psnr_string = ""
+            log.info(f"Creating {metric_type} graph...")
+            plot_graph(
+                f"{metric_type}\nn_subsample: {args.subsample}",
+                "Frame Number",
+                metric_type,
+                frame_numbers,
+                metric_scores,
+                mean_score,
+                os.path.join(output_folder, metric_type),
+            )
 
-    if args.calculate_ssim:
-        ssim_string = "/SSIM"
-
-        for metric in file_contents["frames"][0]["metrics"]:
-            if "ssim" in metric:
-                metric_name = metric
-        
-        # Get the SSIM score of each frame from the JSON file created by libvmaf.
-        ssim_scores = [frame["metrics"][metric_name] for frame in file_contents["frames"]]
-
-        mean_ssim = force_decimal_places(np.mean(ssim_scores), decimal_places)
-        min_ssim = force_decimal_places(min(ssim_scores), decimal_places)
-        ssim_std = force_decimal_places(np.std(ssim_scores), decimal_places)  # Standard deviation.
-
-        log.info(f"Creating SSIM graph...")
-        plot_graph(
-            f"SSIM\nn_subsample: {args.subsample}",
-            "Frame Number",
-            "SSIM",
-            frame_numbers,
-            ssim_scores,
-            mean_ssim,
-            os.path.join(output_folder, "SSIM"),
-        )
-
-        # Add the SSIM values to the table.
-        data_for_current_row.append(f"{min_ssim} | {ssim_std} | {mean_ssim}")
-
-    if args.calculate_psnr:
-        psnr_string = "/PSNR"
-
-        for metric in file_contents["frames"][0]["metrics"]:
-            if "psnr" in metric:
-                metric_name = metric
-
-        # Get the PSNR score of each frame from the JSON file created by libvmaf.
-        psnr_scores = [frame["metrics"][metric_name] for frame in file_contents["frames"]]
-
-        mean_psnr = force_decimal_places(np.mean(psnr_scores), decimal_places)
-        min_psnr = force_decimal_places(min(psnr_scores), decimal_places)
-        psnr_std = force_decimal_places(np.std(psnr_scores), decimal_places)  # Standard deviation.
-
-        log.info(f"Creating PSNR graph...")
-        plot_graph(
-            f"PSNR\nn_subsample: {args.subsample}",
-            "Frame Number",
-            "PSNR",
-            frame_numbers,
-            psnr_scores,
-            mean_psnr,
-            os.path.join(output_folder, "PSNR"),
-        )
-
-        # Add the PSNR values to the table.
-        data_for_current_row.append(f"{min_psnr} | {psnr_std} | {mean_psnr}")
+            # Add the <metric_type> values to the table.
+            data_for_current_row.append(f"{min_score} | {std_score} | {mean_score}")
 
     if not args.no_transcoding_mode:
         data_for_current_row.insert(0, crf_or_preset)
         data_for_current_row.insert(1, time_taken)
 
     table.add_row(data_for_current_row)
+
+    collected_metric_types = '/'.join(metrics_list)
     table_title = (
-        f"VMAF{ssim_string}{psnr_string} values are in the format: Min | Standard Deviation | Mean"
+        f"{collected_metric_types} values are in the format: Min | Standard Deviation | Mean"
     )
 
     # Write the table to the Table.txt file.
@@ -121,4 +86,4 @@ def get_metrics_save_table(
 
     log.info(f"{comparison_table} has been updated.")
     line()
-    return float(mean_vmaf)
+    return float(collected_scores["VMAF"]["mean"])

--- a/utils.py
+++ b/utils.py
@@ -204,6 +204,7 @@ def get_metrics_list(args):
         "VMAF",
         "PSNR" if args.calculate_psnr else None,
         "SSIM" if args.calculate_ssim else None,
+        "MS-SSIM" if args.calculate_msssim else None
     ]
 
     return list(filter(None, metrics_list))

--- a/utils.py
+++ b/utils.py
@@ -198,3 +198,12 @@ def write_table_info(table_path, video_filename, original_bitrate, args, crf_or_
             f'Filter(s) used: {"None" if not args.video_filters else args.video_filters}\n'
             f"n_subsample: {args.subsample}"
         )
+
+def get_metrics_list(args):
+    metrics_list = [
+        "VMAF",
+        "PSNR" if args.calculate_psnr else None,
+        "SSIM" if args.calculate_ssim else None,
+    ]
+
+    return list(filter(None, metrics_list))


### PR DESCRIPTION
This covers the changes I [discussed in my issue](https://github.com/CrypticSignal/video-quality-metrics/issues/40#issuecomment-1061252396).

- **chore:** `PSNR` and `SSIM` metrics logic has been DRY'd up to simplify maintenance.
- **feat:** `MS-SSIM` was added as an additional metric since the changes in this PR make that a very simple addition.
- **chore:** `metrics.py` was refactored to be DRY as each metric repeated the same code.
- **fix:** `PSNR` will now correctly use the `psnr_y` metric which is what earlier versions of libvmaf were providing for the prior `psnr` JSON key.
- **fix:** Prevention of overwriting `feature` and `model` parameters. Extra values to these parameters should instead be appended with a `|` delimiter as per the ffmpeg vmaf docs.

Each commit has a message for extra context if useful :)

Fixes: #40 