### PR TITLE
Improve the compatibility of different versions of Python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ venv/
 .vscode/
 # Don't ignore files in the test_videos folder
 !test_videos/*
+.venv

--- a/ffmpeg_process_factory.py
+++ b/ffmpeg_process_factory.py
@@ -63,7 +63,7 @@ class LibVmafArguments:
         self._distorted_video = distorted_video
         self._video_filters = f"{video_filters}," if video_filters else ""
         self._transcoded_video_scaling = (
-            f"scale={transcoded_video_scaling.replace("x", ":")}:flags=bicubic,"
+            "scale={}:flags=bicubic,".format(transcoded_video_scaling.replace("x", ":"))
             if transcoded_video_scaling
             else ""
         )

--- a/main.py
+++ b/main.py
@@ -154,9 +154,7 @@ if args.no_transcoding_mode:
 vmaf_scores = []
 
 log.info(f"Values of {args.encoder}'s '-{args.parameter}' parameter will be compared.")
-log.info(
-    f"The following values will be compared: {", ".join(str(value) for value in args.values)}"
-)
+log.info("The following values will be compared: {}".format(", ".join(str(value) for value in args.values)))
 
 comparison_table = initialise_table()
 
@@ -192,7 +190,7 @@ for value in args.values:
 
     # Save the output of libvmaf to the following path.
     json_file_path = (
-        f"{current_output_folder.replace("\\", "/")}/per_frame_metrics.json"
+        "{}/per_frame_metrics.json".format(current_output_folder.replace("\\", "/"))
     )
 
     # Run the libvmaf filter.


### PR DESCRIPTION
Use string format instead of  f-string for better compatible with different versions of python, and ignore python venv dir.